### PR TITLE
Added incomplete persistence, improved media obtaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automation script for Instagram that *farms* comments, follows and likes.
 
 <span>
     <img src="https://img.shields.io/static/v1?label=Built%20with&message=Instagrapi&color=red"/>
-    <img src="https://img.shields.io/static/v1?label=Built%20with&message=Python%203.11.0rc2&color=red"/>
+    <img src="https://img.shields.io/static/v1?label=Built%20with&message=Python%203.11.1&color=red"/>
     <a href="https://discord.gg/TY8pt8e5Xg" style="text-decoration: none; border: none; outline: 0;">
         <img src="https://img.shields.io/static/v1?label=Connect%20via&message=Discord&color=5865F2"/>
     </a>

--- a/src/instapy2/instapy2.py
+++ b/src/instapy2/instapy2.py
@@ -1,5 +1,6 @@
 from .instapy2_base import InstaPy2Base
 
+from .persistence import sqlinterface
 from .types import CommentType
 from .types import FollowType
 from .types import LikeType
@@ -189,6 +190,8 @@ class InstaPy2(InstaPy2Base):
                         else:
                             if self.configuration.media.validated_for_interaction(media=media):
                                 liked = self.configuration.likes.like(media=media)
+                                if liked:
+                                    sqlinterface.insert_id(id=media.id)
 
                                 if self.configuration.comments.enabled_for_liked_media or liked:
                                     commenting = random.randint(a=0, b=100) <= self.configuration.comments.percentage
@@ -234,6 +237,8 @@ class InstaPy2(InstaPy2Base):
                     for media in medias:
                         if self.configuration.media.validated_for_interaction(media=media):
                             liked = self.configuration.likes.like(media=media)
+                            if liked:
+                                sqlinterface.insert_id(id=media.id)
 
                             if self.configuration.comments.enabled_for_liked_media or liked:
                                 commenting = random.randint(a=0, b=100) <= self.configuration.comments.percentage

--- a/src/instapy2/instapy2_base.py
+++ b/src/instapy2/instapy2_base.py
@@ -25,7 +25,6 @@ class InstaPy2Base:
             self.session = Client(proxy=proxy())
         else:
             self.session = Client()
-        self.configuration = Configuration(session=self.session)
 
         if not path.exists(path=getcwd() + f'{path.sep}/files'):
             mkdir(path=getcwd() + f'{path.sep}/files')
@@ -37,6 +36,7 @@ class InstaPy2Base:
             logged_in = self.session.login(username=username, password=password, verification_code=verification_code)
             self.session.dump_settings(path=getcwd() + f'{path.sep}files{path.sep}{username}.json')
 
+        self.configuration = Configuration(session=self.session)
         print(f'[INFO]: Successfully logged in as: {self.session.username}.' if logged_in else f'[ERROR]: Failed to log in.')
 
     def set_proxies(self, proxies: List[Dict[str, str]] = None):

--- a/src/instapy2/persistence/__init__.py
+++ b/src/instapy2/persistence/__init__.py
@@ -1,0 +1,1 @@
+from . import sqlinterface

--- a/src/instapy2/persistence/sqlinterface.py
+++ b/src/instapy2/persistence/sqlinterface.py
@@ -1,0 +1,19 @@
+from os import getcwd, path, sep
+import sqlite3
+
+connection = sqlite3.connect(getcwd() + sep + f'files{sep}data.db')
+cursor = connection.cursor()
+
+def create_table():
+    cursor.execute('CREATE TABLE liked_media (id TEXT)')
+
+def insert_id(id):
+    cursor.execute(f'INSERT INTO liked_media VALUES (\'{id}\')')
+    connection.commit()
+
+def show():
+    print(cursor.execute('SELECT * FROM liked_media').fetchall())
+
+
+if cursor.execute('SELECT name FROM sqlite_master WHERE name=\'liked_media\'').fetchone() is None:
+    create_table()


### PR DESCRIPTION
Persistence is only to test my horrid sqlite scripting and is not ready for use, it will be used to store media/user ids, etc.

Media is now obtained in *chunks* using cursors, this will help to fix the "already interacted with" issue.